### PR TITLE
Update KitchenOwl to 0.7.8

### DIFF
--- a/kitchenowl/docker-compose.yml
+++ b/kitchenowl/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       PROXY_AUTH_ADD: "false"
 
   web:
-    image: tombursch/kitchenowl:v0.7.6@sha256:a9db258965941c4183acb87c68bb7704e5af569d54a66fde8f3ed51801bb9949
+    image: tombursch/kitchenowl:v0.7.8@sha256:9f8d7e7849c68b3b516c92938b0489dc6173568f266c48e429556de0cb9d8d82
     user: "1000:1000"
     restart: on-failure
     environment:

--- a/kitchenowl/umbrel-app.yml
+++ b/kitchenowl/umbrel-app.yml
@@ -3,7 +3,7 @@ id: kitchenowl
 name: KitchenOwl
 tagline: A grocery list and recipe manager
 category: files
-version: "0.7.6"
+version: "0.7.8"
 port: 8474
 description: >-
   👨‍🍳 KitchenOwl is a self-hosted, open-source application designed to simplify household management, particularly when it comes to organizing groceries, recipes, meal planning, and shared expenses. Built with privacy and usability in mind, KitchenOwl empowers individuals, families, and shared households to collaboratively manage kitchen-related tasks through a sleek and intuitive interface available on mobile, desktop, and the web.
@@ -36,12 +36,10 @@ gallery:
   - 5.jpg
   - 6.jpg
 releaseNotes: >-
-  This release includes bug fixes and improvements:
-    - Fixed multiple PostgreSQL bugs with the shopping list
-    - Improved markdown rendering
+  This release includes minor fixes and improvements, including fixes for recipe scraping, dynamic colors, Android sync reliability, and iOS session loss caused by background fetch token rotation. It also adds a keep-screen-on setting for shopping lists, OIDC flow launch via query parameter, larger image uploads, and updated translations.
 
 
-  Full release notes: https://github.com/TomBursch/kitchenowl/releases/tag/v0.7.6
+  Full release notes: https://github.com/TomBursch/kitchenowl/releases/tag/v0.7.8
 dependencies: []
 path: ""
 defaultUsername: ""


### PR DESCRIPTION
## What changed

Updated KitchenOwl from `0.7.6` to `0.7.8`.

- Updated the KitchenOwl Docker image tag and digest
- Updated the Umbrel app version and release notes
- Left the Postgres sidecar unchanged because upstream did not indicate a required change

## Upstream

- Release: https://github.com/TomBursch/kitchenowl/releases/tag/v0.7.8
- Summary: Bug fixes and improvements; includes the stopped `v0.7.7` rollout.

## Testing

Devices tested:
- amd64

Standard checks:
- ✅ App installed successfully
- ✅ App reached ready state
- ✅ Web UI loaded at the app URL
- ✅ No obvious container errors in logs

App-specific checks:
- ✅ Created a disposable KitchenOwl user
- ✅ Created disposable household: `Kai Test Household 20260506`
- ✅ Added disposable shopping list item: `Kai Test Milk 20260506`

Screenshots attached:
1. amd64 — KitchenOwl web UI loaded

   ![amd64 KitchenOwl web UI loaded](https://raw.githubusercontent.com/kaichappel/umbrel-app-update-evidence/main/kitchenowl/0.7.8/2026-05-06-kitchenowl-0.7.8/screenshots/01-web-ui-loaded.png)

2. amd64 — logged-in household screen

   ![amd64 KitchenOwl logged-in household screen](https://raw.githubusercontent.com/kaichappel/umbrel-app-update-evidence/main/kitchenowl/0.7.8/2026-05-06-kitchenowl-0.7.8/screenshots/02-household-screen.png)

3. amd64 — disposable shopping list item visible

   ![amd64 KitchenOwl disposable shopping list item visible](https://raw.githubusercontent.com/kaichappel/umbrel-app-update-evidence/main/kitchenowl/0.7.8/2026-05-06-kitchenowl-0.7.8/screenshots/03-shopping-list-item.png)

## Notes

- None.